### PR TITLE
accumulo-site, refactor, env, example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+splits.txt

--- a/1.8.1/Dockerfile
+++ b/1.8.1/Dockerfile
@@ -33,10 +33,6 @@ RUN curl -o hadoop-$HADOOP_VERSION.tar.gz "https://archive.apache.org/dist/hadoo
     && rm -f hadoop-HADOOP_VERSION.tar.gz \
     && yum clean all
 
-RUN mkdir -p /home/hadoop/hdfs/namenode \
-    && mkdir -p /home/hadoop/hdfs/datanode \
-    && mkdir -p /home/hadoop/public
-
 WORKDIR /root/
 USER root
 RUN ssh-keygen -q -N '' -t rsa -f /root/.ssh/id_rsa \
@@ -80,7 +76,7 @@ ENV ACCUMULO_VERSION=${ACCUMULO_VERSION} \
   ZOOKEEPER_HOME=/home/hadoop/zookeeper \
   ZOOKEEPER_NODES=''
 
-VOLUME ["/site-files"]
+VOLUME ["/site-files", "/home/hadoop/public"]
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY zookeeper-${ZOOKEEPER_VERSION}.jar /home/hadoop/zookeeper/zookeeper-${ZOOKEEPER_VERSION}.jar

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Automated builds are generated at: [https://hub.docker.com/u/renci](https://hub.
 $ docker pull renci/accumulo:1.8.1
 ```
 
-## Example
+## Example: Seven node cluster
 
 Using the provided [`docker-compose.yml`](docker-compose.yml) file to stand up a seven node Accumulo cluster that includes an `accumulomaster`, `namenode`, `resourcemanager`, two workers (`worker1` and `worker2`) and two [ZooKeeper](https://hub.docker.com/r/renci/zookeeper/) nodes (`zoo` and `zoo2`).
 
@@ -331,6 +331,43 @@ Removing namenode        ... done
 Removing zoo1            ... done
 Removing zoo2            ... done
 ```
+
+## Example: Accumulo command line
+
+**NOTE**: Assumes the cluster is running as configured in the previous example.
+
+A script named [usertable-example.sh](usertable-example.sh) will create a sample `usertable` in Accumulo using 100 randomly generated user entries using `docker exec` calls to the `accumulomaster` container.
+
+```
+$ ./usertable-example.sh
+INFO: generate splits.txt
+user5525
+user1588
+...
+user7717
+user5402
+docker cp splits.txt accumulomaster:/tmp/splits.txt
+INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "deletetable -f usertable"
+2018-02-18 04:31:54,248 [trace.DistributedTrace] INFO : SpanReceiver org.apache.accumulo.tracer.ZooTraceClient was loaded successfully.
+Table: [usertable] has been deleted.
+INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "createtable usertable"
+2018-02-18 04:31:57,638 [trace.DistributedTrace] INFO : SpanReceiver org.apache.accumulo.tracer.ZooTraceClient was loaded successfully.
+INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "addsplits -t usertable -sf /tmp/splits.txt"
+2018-02-18 04:32:00,522 [trace.DistributedTrace] INFO : SpanReceiver org.apache.accumulo.tracer.ZooTraceClient was loaded successfully.
+INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "config -t usertable -s table.cache.block.enable=true"
+2018-02-18 04:32:06,503 [trace.DistributedTrace] INFO : SpanReceiver org.apache.accumulo.tracer.ZooTraceClient was loaded successfully.
+INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e tables
+2018-02-18 04:32:08,965 [trace.DistributedTrace] INFO : SpanReceiver org.apache.accumulo.tracer.ZooTraceClient was loaded successfully.
+accumulo.metadata
+accumulo.replication
+accumulo.root
+trace
+usertable
+```
+
+AccumuloMaster: [http://localhost:9995/master](http://localhost:9995/master)
+
+<img width="50%" alt="AccumuloMaster usertable example" src="https://user-images.githubusercontent.com/5332509/36348341-5ddf74ba-143b-11e8-93b4-0930648e0b58.png">
 
 ### References
 

--- a/site-files/accumulo-site.xml
+++ b/site-files/accumulo-site.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <!-- Put your site-specific accumulo configurations here. The available configuration values along with their defaults are documented in docs/config.html Unless
+    you are simply testing at your workstation, you will most definitely need to change the three entries below. -->
+
+  <property>
+    <name>instance.volumes</name>
+    <value>hdfs://namenode:9000/accumulo</value>
+    <description>comma separated list of URIs for volumes. example: hdfs://localhost:9000/accumulo</description>
+  </property>
+
+  <property>
+    <name>instance.zookeeper.host</name>
+    <value>zoo1:2181,zoo2:2181</value>
+    <description>comma separated list of zookeeper servers</description>
+  </property>
+
+  <property>
+    <name>instance.secret</name>
+    <value>DEFAULT</value>
+    <description>A secret unique to a given instance that all servers must know in order to communicate with one another.
+      Change it before initialization. To
+      change it later use ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret --old [oldpasswd] --new [newpasswd],
+      and then update this file.
+    </description>
+  </property>
+
+  <property>
+    <name>tserver.memory.maps.max</name>
+    <value>256M</value>
+  </property>
+
+  <property>
+    <name>tserver.memory.maps.native.enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>tserver.cache.data.size</name>
+    <value>15M</value>
+  </property>
+
+  <property>
+    <name>tserver.cache.index.size</name>
+    <value>40M</value>
+  </property>
+
+  <property>
+    <name>trace.token.property.password</name>
+    <!-- change this to the root user's password, and/or change the user below -->
+    <value>secret</value>
+  </property>
+
+  <!-- Kerberos requirements --><!--
+  <property>
+    <name>instance.rpc.sasl.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>general.kerberos.keytab</name>
+    <value>${keytab}</value>
+  </property>
+
+  <property>
+    <name>general.kerberos.principal</name>
+    <value>${principal}</value>
+  </property>
+
+  <property>
+    <name>trace.token.type</name>
+    <value>org.apache.accumulo.core.client.security.tokens.KerberosToken</value>
+  </property>
+
+  <property>
+    <name>instance.security.authenticator</name>
+    <value>org.apache.accumulo.server.security.handler.KerberosAuthenticator</value>
+  </property>
+
+  <property>
+    <name>instance.security.authorizor</name>
+    <value>org.apache.accumulo.server.security.handler.KerberosAuthorizor</value>
+  </property>
+
+  <property>
+    <name>instance.security.permissionHandler</name>
+    <value>org.apache.accumulo.server.security.handler.KerberosPermissionHandler</value>
+  </property>
+  --><!-- End Kerberos requirements -->
+
+  <property>
+    <name>trace.user</name>
+    <value>root</value>
+  </property>
+
+  <property>
+    <name>tserver.sort.buffer.size</name>
+    <value>50M</value>
+  </property>
+
+  <property>
+    <name>tserver.walog.max.size</name>
+    <value>256M</value>
+  </property>
+
+  <property>
+    <name>general.classpaths</name>
+
+    <value>
+      <!-- Accumulo requirements -->
+      $ACCUMULO_HOME/lib/accumulo-server.jar,
+      $ACCUMULO_HOME/lib/accumulo-core.jar,
+      $ACCUMULO_HOME/lib/accumulo-start.jar,
+      $ACCUMULO_HOME/lib/accumulo-fate.jar,
+      $ACCUMULO_HOME/lib/accumulo-proxy.jar,
+      $ACCUMULO_HOME/lib/[^.].*.jar,
+      <!-- ZooKeeper requirements -->
+      $ZOOKEEPER_HOME/zookeeper[^.].*.jar,
+      <!-- Common Hadoop requirements -->
+      $HADOOP_CONF_DIR,
+      <!-- Hadoop 2 requirements -->
+      $HADOOP_PREFIX/share/hadoop/common/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/common/lib/(?!slf4j)[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/hdfs/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/mapreduce/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/yarn/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/yarn/lib/jersey.*.jar,
+      <!-- End Hadoop 2 requirements -->
+      <!-- HDP 2.0 requirements --><!--
+      /usr/lib/hadoop/[^.].*.jar,
+      /usr/lib/hadoop/lib/[^.].*.jar,
+      /usr/lib/hadoop-hdfs/[^.].*.jar,
+      /usr/lib/hadoop-mapreduce/[^.].*.jar,
+      /usr/lib/hadoop-yarn/[^.].*.jar,
+      /usr/lib/hadoop-yarn/lib/jersey.*.jar,
+      --><!-- End HDP 2.0 requirements -->
+      <!-- HDP 2.2 requirements --><!--
+      /usr/hdp/current/hadoop-client/[^.].*.jar,
+      /usr/hdp/current/hadoop-client/lib/(?!slf4j)[^.].*.jar,
+      /usr/hdp/current/hadoop-hdfs-client/[^.].*.jar,
+      /usr/hdp/current/hadoop-mapreduce-client/[^.].*.jar,
+      /usr/hdp/current/hadoop-yarn-client/[^.].*.jar,
+      /usr/hdp/current/hadoop-yarn-client/lib/jersey.*.jar,
+      /usr/hdp/current/hive-client/lib/hive-accumulo-handler.jar
+      --><!-- End HDP 2.2 requirements -->
+      <!-- IOP 4.1 requirements --><!--
+      /usr/iop/current/hadoop-client/[^.].*.jar,
+      /usr/iop/current/hadoop-client/lib/(?!slf4j)[^.].*.jar,
+      /usr/iop/current/hadoop-hdfs-client/[^.].*.jar,
+      /usr/iop/current/hadoop-mapreduce-client/[^.].*.jar,
+      /usr/iop/current/hadoop-yarn-client/[^.].*.jar,
+      /usr/iop/current/hadoop-yarn-client/lib/jersey.*.jar,
+      /usr/iop/current/hive-client/lib/hive-accumulo-handler.jar
+      --><!-- End IOP 4.1 requirements -->
+    </value>
+    <description>Classpaths that accumulo checks for updates and class files.</description>
+  </property>
+</configuration>

--- a/site-files/core-site.xml
+++ b/site-files/core-site.xml
@@ -2,8 +2,8 @@
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!-- Put site-specific property overrides in this file. -->
 <configuration>
-    <property>
-        <name>fs.default.name</name>
-        <value>hdfs://namenode:9000</value>
-    </property>
+  <property>
+    <name>fs.default.name</name>
+    <value>hdfs://namenode:9000</value>
+  </property>
 </configuration>

--- a/site-files/hdfs-site.xml
+++ b/site-files/hdfs-site.xml
@@ -3,11 +3,15 @@
 <!-- Put site-specific property overrides in this file. -->
 <configuration>
   <property>
-     <name>dfs.replication</name>
-     <value>2</value>
+    <name>dfs.replication</name>
+    <value>2</value>
   </property>
   <property>
-    <name>dfs.datanode.synconclose</name>
-    <value>true</value>
+    <name>dfs.name.dir</name>
+    <value>file:///hdfsdata/namenode</value>
+  </property>
+  <property>
+    <name>dfs.data.dir</name>
+    <value>file:///hdfsdata/datanode</value>
   </property>
 </configuration>

--- a/site-files/yarn-site.xml
+++ b/site-files/yarn-site.xml
@@ -17,4 +17,8 @@
     <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
     <value>org.apache.hadoop.mapred.ShuffleHandler</value>
   </property>
+  <property>
+    <name>yarn.resourcemanager.address</name>
+    <value>resourcemanager:8032</value>
+  </property>
 </configuration>

--- a/usertable-example.sh
+++ b/usertable-example.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+echo "INFO: generate splits.txt"
+> splits.txt
+for run in {1..100}
+do
+  echo 'user'$((1000 + RANDOM % 8999)) >> splits.txt
+done
+cat splits.txt
+
+echo "docker cp splits.txt accumulomaster:/tmp/splits.txt"
+docker cp splits.txt accumulomaster:/tmp/splits.txt
+
+echo 'INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "deletetable -f usertable"'
+docker exec -ti accumulomaster runuser -l hadoop -c '${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "deletetable -f usertable"'
+
+echo 'INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "createtable usertable"'
+docker exec -ti accumulomaster runuser -l hadoop -c '${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "createtable usertable"'
+
+# addsplits -t usertable -sf /tmp/splits.txt
+echo 'INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "addsplits -t usertable -sf /tmp/splits.txt"'
+docker exec -ti accumulomaster runuser -l hadoop -c '${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "addsplits -t usertable -sf /tmp/splits.txt"'
+
+# config -t usertable -s table.cache.block.enable=true
+echo 'INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "config -t usertable -s table.cache.block.enable=true"'
+docker exec -ti accumulomaster runuser -l hadoop -c '${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e "config -t usertable -s table.cache.block.enable=true"'
+
+echo 'INFO: ${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e tables'
+docker exec -ti accumulomaster runuser -l hadoop -c '${ACCUMULO_HOME}/bin/accumulo shell -u root -p secret -e tables'
+
+exit 0;


### PR DESCRIPTION
- Add accumulo-site.xml option as included site-file. 
- Refactor code to allow more flexibility at runtime. 
- Update env for hadoop user. 
- Create usertable example to match that from the exongeni blog.